### PR TITLE
Set field_rights to full_html

### DIFF
--- a/create_islandora_objects.yml
+++ b/create_islandora_objects.yml
@@ -8,6 +8,8 @@ subdelimiter: "|"
 allow_adding_terms: true
 input_dir: '/path/to/islandora_demo_objects'
 ignore_csv_columns: ["Transcript", "Supplemental_PDF", "field_display_hints"]
+field_text_format_ids:
+  - field_rights: full_html
 additional_files:
  - extracted: DRUPAL_EXTRACTED_TERM_ID
  - fits: DRUPAL_FITS_TERM_ID


### PR DESCRIPTION
This is @rosiel, masquerading today as @alxp.

When loading the sandbox we are getting red error x's in place of the "Creative Commons" image logos that are being embedded in field_rights.

This PR should set the text format from basic_html (default) to full_html, so that the images can be viewed. The extended reason is that in the starter site (and, presumably, the standard drupal install), basic_html does not allow external images to be embedded. It seems prudent to keep this setting for any users who we want to let use the basic_html type (e.g. commenters...)
