### PR TITLE
Use External URI's to identify terms

### DIFF
--- a/create_islandora_objects.yml
+++ b/create_islandora_objects.yml
@@ -11,7 +11,7 @@ ignore_csv_columns: ["Transcript", "Supplemental_PDF", "field_display_hints"]
 field_text_format_ids:
   - field_rights: full_html
 additional_files:
- - extracted: DRUPAL_EXTRACTED_TERM_ID
- - fits: DRUPAL_FITS_TERM_ID
- - service: DRUPAL_SERVICE_TERM_ID
- - thumbnail: DRUPAL_THUMBNAIL_TERM_ID
+ - extracted: http://pcdm.org/use#ExtractedText
+ - fits: https://projects.iq.harvard.edu/fits
+ - service: http://pcdm.org/use#ServiceFile
+ - thumbnail: http://pcdm.org/use#ThumbnailImage


### PR DESCRIPTION
This repo is hard to use because the workbench config file has placeholders (variables) where the tid or external URI of media use terms should be.

@nigelgbanks  What would be the impact on Sandbox of changing this? I know that sandbox uses a [lookup function](https://github.com/Islandora-Devops/sandbox/blob/c695f5f4eb418f9092f1b9b5b08edb3ceb2eeeff/drupal/rootfs/etc/s6-overlay/scripts/install.sh#L49-L51) and then [exports the term IDs as environment variables](https://github.com/Islandora-Devops/sandbox/blob/c695f5f4eb418f9092f1b9b5b08edb3ceb2eeeff/drupal/rootfs/etc/s6-overlay/scripts/install.sh#L62-L70).  Can we just put the external URIs in? 

Note: i have tested this in Workbench and it works - external uri can identify the term as well as a tid.