### PR TITLE
Assigns fits_technical_metadata mediatype for tagged media

### DIFF
--- a/create_islandora_objects.yml
+++ b/create_islandora_objects.yml
@@ -15,3 +15,6 @@ additional_files:
  - fits: https://projects.iq.harvard.edu/fits
  - service: http://pcdm.org/use#ServiceFile
  - thumbnail: http://pcdm.org/use#ThumbnailImage
+media_type_by_media_use:
+  - https://projects.iq.harvard.edu/fits: fits_technical_metadata
+


### PR DESCRIPTION
This uses the new config parameter which pulls the fits XML in as `fits_technical_metadata` media type rather than the default `file`, which is based on the file's mime-type.